### PR TITLE
Add unit tests for start.py (FRE-122)

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,3 +6,4 @@ requests==2.32.3
 python-dotenv~=1.0.1
 pytest>=8.0,<9.0
 pytest-cov>=5.0,<6.0
+pytest-mock>=3.10

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ actual Raspberry Pi hardware.
 """
 
 import sys
+import os
 from unittest.mock import MagicMock
 
 # Mock hardware-specific modules that aren't available in CI
@@ -17,8 +18,24 @@ HARDWARE_MODULES = [
     "gpiozero",
     "w1thermsensor",
     "pisugar",
+    "smbus",
+    "smbus2",
+    "spidev",
 ]
 
 for mod in HARDWARE_MODULES:
     if mod not in sys.modules:
         sys.modules[mod] = MagicMock()
+
+# Make gpiozero.CPUTemperature return a mock with .temperature
+cpu_temp_mock = MagicMock()
+cpu_temp_mock.return_value.temperature = 45.0
+sys.modules['gpiozero'].CPUTemperature = cpu_temp_mock
+
+# Make w1thermsensor.W1ThermSensor a proper mock
+w1_mock_class = MagicMock()
+w1_mock_class.return_value.get_temperature.return_value = -20.0
+sys.modules['w1thermsensor'].W1ThermSensor = w1_mock_class
+
+# Add raspberry_pi directory to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'raspberry_pi'))

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -1,0 +1,166 @@
+"""Unit tests for start.py (FRE-122)"""
+import sys
+import pytest
+from unittest.mock import patch, MagicMock, call
+
+
+@pytest.fixture(autouse=True)
+def mock_dependencies():
+    """Mock all dependencies before importing start."""
+    # Mock config module
+    mock_config_cls = MagicMock()
+    config_mod = MagicMock()
+    config_mod.Config = mock_config_cls
+    sys.modules['config'] = config_mod
+
+    # Remove cached start module to force reimport with fresh mocks
+    sys.modules.pop('start', None)
+
+    yield {'config_cls': mock_config_cls}
+
+    # Cleanup
+    for mod_name in ['start', 'config']:
+        sys.modules.pop(mod_name, None)
+
+
+def _import_start():
+    sys.modules.pop('start', None)
+    import start
+    return start
+
+
+class TestEnsureUpdaterIsActive:
+    """Tests for ensure_updater_is_active()"""
+
+    @patch('subprocess.run')
+    def test_enables_updater_timer(self, mock_run, mock_dependencies):
+        start = _import_start()
+        start.ensure_updater_is_active()
+        mock_run.assert_any_call(["sudo", "systemctl", "enable", "freezerbot-updater.timer"])
+
+    @patch('subprocess.run')
+    def test_restarts_updater_timer(self, mock_run, mock_dependencies):
+        start = _import_start()
+        start.ensure_updater_is_active()
+        mock_run.assert_any_call(["sudo", "systemctl", "restart", "freezerbot-updater.timer"])
+
+    @patch('subprocess.run')
+    def test_calls_exactly_two_commands(self, mock_run, mock_dependencies):
+        start = _import_start()
+        start.ensure_updater_is_active()
+        assert mock_run.call_count == 2
+
+
+class TestDetermineMode:
+    """Tests for determine_mode()"""
+
+    @patch('subprocess.run')
+    def test_configured_starts_monitor_service(self, mock_run, mock_dependencies):
+        mock_dependencies['config_cls'].return_value.is_configured = True
+        start = _import_start()
+        start.determine_mode()
+
+        mock_run.assert_any_call(["sudo", "systemctl", "enable", "freezerbot-monitor.service"])
+        mock_run.assert_any_call(["sudo", "systemctl", "restart", "freezerbot-monitor.service"])
+
+    @patch('subprocess.run')
+    def test_configured_stops_setup_service(self, mock_run, mock_dependencies):
+        mock_dependencies['config_cls'].return_value.is_configured = True
+        start = _import_start()
+        start.determine_mode()
+
+        mock_run.assert_any_call(["sudo", "systemctl", "disable", "freezerbot-setup.service"])
+        mock_run.assert_any_call(["sudo", "systemctl", "stop", "freezerbot-setup.service"])
+
+    @patch('subprocess.run')
+    def test_unconfigured_starts_setup_service(self, mock_run, mock_dependencies):
+        mock_dependencies['config_cls'].return_value.is_configured = False
+        start = _import_start()
+        start.determine_mode()
+
+        mock_run.assert_any_call(["sudo", "systemctl", "enable", "freezerbot-setup.service"])
+        mock_run.assert_any_call(["sudo", "systemctl", "restart", "freezerbot-setup.service"])
+
+    @patch('subprocess.run')
+    def test_unconfigured_stops_monitor_service(self, mock_run, mock_dependencies):
+        mock_dependencies['config_cls'].return_value.is_configured = False
+        start = _import_start()
+        start.determine_mode()
+
+        mock_run.assert_any_call(["sudo", "systemctl", "disable", "freezerbot-monitor.service"])
+        mock_run.assert_any_call(["sudo", "systemctl", "stop", "freezerbot-monitor.service"])
+
+    @patch('subprocess.run')
+    def test_always_ensures_updater_active(self, mock_run, mock_dependencies):
+        """Updater timer should be enabled regardless of config state."""
+        mock_dependencies['config_cls'].return_value.is_configured = True
+        start = _import_start()
+        start.determine_mode()
+
+        mock_run.assert_any_call(["sudo", "systemctl", "enable", "freezerbot-updater.timer"])
+        mock_run.assert_any_call(["sudo", "systemctl", "restart", "freezerbot-updater.timer"])
+
+    @patch('subprocess.run')
+    def test_configured_runs_six_commands_total(self, mock_run, mock_dependencies):
+        """2 updater + 4 service commands = 6 total."""
+        mock_dependencies['config_cls'].return_value.is_configured = True
+        start = _import_start()
+        start.determine_mode()
+        assert mock_run.call_count == 6
+
+    @patch('subprocess.run')
+    def test_unconfigured_runs_six_commands_total(self, mock_run, mock_dependencies):
+        mock_dependencies['config_cls'].return_value.is_configured = False
+        start = _import_start()
+        start.determine_mode()
+        assert mock_run.call_count == 6
+
+    @patch('subprocess.run')
+    def test_configured_prints_monitor_message(self, mock_run, mock_dependencies, capsys):
+        mock_dependencies['config_cls'].return_value.is_configured = True
+        start = _import_start()
+        start.determine_mode()
+        captured = capsys.readouterr()
+        assert 'starting freezerbot-monitor.service' in captured.out
+
+    @patch('subprocess.run')
+    def test_unconfigured_prints_setup_message(self, mock_run, mock_dependencies, capsys):
+        mock_dependencies['config_cls'].return_value.is_configured = False
+        start = _import_start()
+        start.determine_mode()
+        captured = capsys.readouterr()
+        assert 'starting freezerbot-setup.service' in captured.out
+
+    @patch('subprocess.run')
+    def test_updater_called_before_service_commands(self, mock_run, mock_dependencies):
+        """ensure_updater_is_active should run before the service enable/disable logic."""
+        mock_dependencies['config_cls'].return_value.is_configured = True
+        start = _import_start()
+        start.determine_mode()
+
+        calls = mock_run.call_args_list
+        # First two calls should be the updater timer
+        assert calls[0] == call(["sudo", "systemctl", "enable", "freezerbot-updater.timer"])
+        assert calls[1] == call(["sudo", "systemctl", "restart", "freezerbot-updater.timer"])
+
+    @patch('subprocess.run')
+    def test_configured_does_not_enable_setup_service(self, mock_run, mock_dependencies):
+        """When configured, setup service should be disabled, not enabled."""
+        mock_dependencies['config_cls'].return_value.is_configured = True
+        start = _import_start()
+        start.determine_mode()
+
+        enable_calls = [c for c in mock_run.call_args_list
+                        if c == call(["sudo", "systemctl", "enable", "freezerbot-setup.service"])]
+        assert len(enable_calls) == 0
+
+    @patch('subprocess.run')
+    def test_unconfigured_does_not_enable_monitor_service(self, mock_run, mock_dependencies):
+        """When unconfigured, monitor service should be disabled, not enabled."""
+        mock_dependencies['config_cls'].return_value.is_configured = False
+        start = _import_start()
+        start.determine_mode()
+
+        enable_calls = [c for c in mock_run.call_args_list
+                        if c == call(["sudo", "systemctl", "enable", "freezerbot-monitor.service"])]
+        assert len(enable_calls) == 0


### PR DESCRIPTION
## Summary

Adds 15 unit tests for `start.py`, covering both functions:

### `ensure_updater_is_active()`
- Verifies updater timer is enabled and restarted
- Confirms exactly 2 systemctl commands are issued

### `determine_mode()`
- Configured path: enables/restarts monitor service, disables/stops setup service
- Unconfigured path: enables/restarts setup service, disables/stops monitor service
- Updater timer is always activated regardless of config state
- Correct ordering (updater first, then service commands)
- Negative tests: configured doesn't enable setup, unconfigured doesn't enable monitor
- Correct print output for each path
- Exactly 6 systemctl commands per path (2 updater + 4 service)

All 15 tests passing.

Resolves FRE-122