### PR TITLE
Add unit tests for restarts.py (FRE-121)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ actual Raspberry Pi hardware.
 """
 
 import sys
+import os
 from unittest.mock import MagicMock
 
 # Mock hardware-specific modules that aren't available in CI
@@ -17,8 +18,24 @@ HARDWARE_MODULES = [
     "gpiozero",
     "w1thermsensor",
     "pisugar",
+    "smbus",
+    "smbus2",
+    "spidev",
 ]
 
 for mod in HARDWARE_MODULES:
     if mod not in sys.modules:
         sys.modules[mod] = MagicMock()
+
+# Make gpiozero.CPUTemperature return a mock with .temperature
+cpu_temp_mock = MagicMock()
+cpu_temp_mock.return_value.temperature = 45.0
+sys.modules['gpiozero'].CPUTemperature = cpu_temp_mock
+
+# Make w1thermsensor.W1ThermSensor a proper mock
+w1_mock_class = MagicMock()
+w1_mock_class.return_value.get_temperature.return_value = -20.0
+sys.modules['w1thermsensor'].W1ThermSensor = w1_mock_class
+
+# Add raspberry_pi directory to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'raspberry_pi'))

--- a/tests/test_restarts.py
+++ b/tests/test_restarts.py
@@ -1,0 +1,66 @@
+from unittest.mock import patch, call
+import restarts
+
+
+class TestRestartInSetupMode:
+    @patch("restarts.subprocess.run")
+    @patch("restarts.time.sleep")
+    def test_sleeps_2_seconds_at_start(self, mock_sleep, mock_run):
+        restarts.restart_in_setup_mode()
+        mock_sleep.assert_called_once_with(2)
+
+    @patch("restarts.subprocess.run")
+    @patch("restarts.time.sleep")
+    def test_enables_setup_disables_monitor(self, mock_sleep, mock_run):
+        restarts.restart_in_setup_mode()
+        mock_run.assert_any_call(["/usr/bin/systemctl", "enable", "freezerbot-setup.service"])
+        mock_run.assert_any_call(["/usr/bin/systemctl", "restart", "freezerbot-setup.service"])
+        mock_run.assert_any_call(["/usr/bin/systemctl", "disable", "freezerbot-monitor.service"])
+        mock_run.assert_any_call(["/usr/bin/systemctl", "stop", "freezerbot-monitor.service"])
+
+    @patch("restarts.subprocess.run")
+    @patch("restarts.time.sleep")
+    def test_correct_call_order(self, mock_sleep, mock_run):
+        restarts.restart_in_setup_mode()
+        assert mock_run.call_args_list == [
+            call(["/usr/bin/systemctl", "enable", "freezerbot-setup.service"]),
+            call(["/usr/bin/systemctl", "restart", "freezerbot-setup.service"]),
+            call(["/usr/bin/systemctl", "disable", "freezerbot-monitor.service"]),
+            call(["/usr/bin/systemctl", "stop", "freezerbot-monitor.service"]),
+        ]
+
+
+class TestRestartInSensorMode:
+    @patch("restarts.subprocess.run")
+    @patch("restarts.time.sleep")
+    def test_stops_services_and_enables_monitor(self, mock_sleep, mock_run):
+        restarts.restart_in_sensor_mode()
+        mock_run.assert_any_call(["/usr/bin/systemctl", "stop", "hostapd.service"])
+        mock_run.assert_any_call(["/usr/bin/systemctl", "stop", "dnsmasq.service"])
+        mock_run.assert_any_call(["/usr/bin/nmcli", "device", "set", "wlan0", "managed", "yes"])
+        mock_run.assert_any_call(["/usr/bin/systemctl", "restart", "NetworkManager.service"])
+        mock_run.assert_any_call(["/usr/bin/systemctl", "enable", "freezerbot-monitor.service"])
+        mock_run.assert_any_call(["/usr/bin/systemctl", "restart", "freezerbot-monitor.service"])
+        mock_run.assert_any_call(["/usr/bin/systemctl", "disable", "freezerbot-setup.service"])
+        mock_run.assert_any_call(["/usr/bin/systemctl", "stop", "freezerbot-setup.service"])
+
+    @patch("restarts.subprocess.run")
+    @patch("restarts.time.sleep")
+    def test_sleeps_5_seconds_after_network_manager_restart(self, mock_sleep, mock_run):
+        restarts.restart_in_sensor_mode()
+        mock_sleep.assert_called_once_with(5)
+
+    @patch("restarts.subprocess.run")
+    @patch("restarts.time.sleep")
+    def test_correct_call_order(self, mock_sleep, mock_run):
+        restarts.restart_in_sensor_mode()
+        assert mock_run.call_args_list == [
+            call(["/usr/bin/systemctl", "stop", "hostapd.service"]),
+            call(["/usr/bin/systemctl", "stop", "dnsmasq.service"]),
+            call(["/usr/bin/nmcli", "device", "set", "wlan0", "managed", "yes"]),
+            call(["/usr/bin/systemctl", "restart", "NetworkManager.service"]),
+            call(["/usr/bin/systemctl", "enable", "freezerbot-monitor.service"]),
+            call(["/usr/bin/systemctl", "restart", "freezerbot-monitor.service"]),
+            call(["/usr/bin/systemctl", "disable", "freezerbot-setup.service"]),
+            call(["/usr/bin/systemctl", "stop", "freezerbot-setup.service"]),
+        ]


### PR DESCRIPTION
Adds unit tests for `raspberry_pi/restarts.py` covering both `restart_in_setup_mode` and `restart_in_sensor_mode` functions.

**Tests cover:**
- Correct systemctl commands called for each function
- Correct call order
- Appropriate sleep delays (2s for setup mode, 5s for sensor mode)

Resolves FRE-121

@mycarrysun please review