### PR TITLE
Fix test_restarts failures caused by test_led_control polluting sys.modules

### DIFF
--- a/tests/test_led_control.py
+++ b/tests/test_led_control.py
@@ -27,6 +27,8 @@ def _import_led_control():
 
 @pytest.fixture(autouse=True)
 def reset_singleton():
+    # Save modules that _import_led_control replaces so we can restore them
+    saved_modules = {k: sys.modules.get(k) for k in ('restarts', 'api', 'config')}
     yield
     for mod_name in list(sys.modules.keys()):
         if 'led_control' in mod_name:
@@ -37,6 +39,12 @@ def reset_singleton():
                     lc_mod.LedControl._initialized = False
             except Exception:
                 pass
+    # Restore modules that were replaced with MagicMocks
+    for mod_name, mod in saved_modules.items():
+        if mod is not None:
+            sys.modules[mod_name] = mod
+        elif mod_name in sys.modules:
+            del sys.modules[mod_name]
 
 
 def _make_lc():


### PR DESCRIPTION
## Problem

`test_led_control.py`'s `_import_led_control()` replaces `sys.modules['restarts']` with a MagicMock but never restores it. When pytest runs `test_restarts.py` after `test_led_control.py`, `@patch('restarts.subprocess.run')` patches a MagicMock attribute instead of the real restarts module — causing all restarts tests to fail with 'Expected sleep to be called once. Called 0 times' and FileNotFoundError.

This broke main when PR #11 was merged.

## Fix

Save and restore the affected modules in the autouse `reset_singleton` fixture teardown.

Fixes the CI failure on main that's blocking PRs #12 and #13.