### PR TITLE
Offline buffering for temperature readings

### DIFF
--- a/raspberry_pi/offline_buffer.py
+++ b/raspberry_pi/offline_buffer.py
@@ -1,0 +1,75 @@
+"""
+Offline buffer for temperature readings using SQLite.
+
+When the API is unreachable due to connectivity failures, readings are stored
+locally and sent as a batch once connectivity is restored.
+"""
+import json
+import os
+import sqlite3
+from datetime import datetime
+
+DB_PATH = '/home/pi/.config/freezerbot/readings_buffer.db'
+
+
+class OfflineBuffer:
+    def __init__(self, db_path: str = DB_PATH):
+        self.db_path = db_path
+        self._ensure_db()
+
+    def _ensure_db(self):
+        """Create the database and table if they don't exist."""
+        os.makedirs(os.path.dirname(self.db_path), exist_ok=True)
+        with self._connect() as conn:
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS readings (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    payload_json TEXT NOT NULL,
+                    taken_at TEXT NOT NULL,
+                    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+                )
+            """)
+
+    def _connect(self):
+        return sqlite3.connect(self.db_path)
+
+    def add_reading(self, payload: dict, timestamp: str) -> None:
+        """Store a reading with its original timestamp."""
+        with self._connect() as conn:
+            conn.execute(
+                "INSERT INTO readings (payload_json, taken_at) VALUES (?, ?)",
+                (json.dumps(payload), timestamp),
+            )
+
+    def get_buffered_readings(self) -> list:
+        """Return all buffered readings in FIFO order."""
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT id, payload_json, taken_at FROM readings ORDER BY id ASC"
+            ).fetchall()
+        return [
+            {'id': row[0], 'payload': json.loads(row[1]), 'taken_at': row[2]}
+            for row in rows
+        ]
+
+    def clear_buffer(self) -> None:
+        """Delete all readings after a successful batch send."""
+        with self._connect() as conn:
+            conn.execute("DELETE FROM readings")
+
+    def prune_to_limit(self, limit: int = 1440) -> None:
+        """Drop oldest readings when buffer exceeds the given limit (24h cap at 1/min)."""
+        with self._connect() as conn:
+            count = conn.execute("SELECT COUNT(*) FROM readings").fetchone()[0]
+            excess = count - limit
+            if excess > 0:
+                conn.execute("""
+                    DELETE FROM readings WHERE id IN (
+                        SELECT id FROM readings ORDER BY id ASC LIMIT ?
+                    )
+                """, (excess,))
+
+    def count(self) -> int:
+        """Return the number of buffered readings."""
+        with self._connect() as conn:
+            return conn.execute("SELECT COUNT(*) FROM readings").fetchone()[0]

--- a/raspberry_pi/temperature_monitor.py
+++ b/raspberry_pi/temperature_monitor.py
@@ -12,6 +12,7 @@ from api import make_api_request, api_token_exists, set_api_token, make_api_requ
 from freezerbot_setup import FreezerBotSetup
 from config import Config
 from battery import PiSugarMonitor
+from offline_buffer import OfflineBuffer
 from network import test_internet_connectivity, load_network_status, save_network_status, reset_network_status, \
     get_current_wifi_ssid, get_wifi_signal_strength, get_ip_address, get_mac_address, get_configured_wifi_networks
 from device_info import DeviceInfo
@@ -31,6 +32,7 @@ class TemperatureMonitor:
         self.network_status = load_network_status()
         self.network_failure_count = self.network_status.get('network_failure_count', 0)
         self.reboot_count = self.network_status.get('reboot_count', 0)
+        self.offline_buffer = OfflineBuffer()
         self.max_reboots = 3
         self.sensor = None
         self.consecutive_sensor_errors = 0
@@ -124,9 +126,37 @@ class TemperatureMonitor:
             self.report_and_reboot_system(failure_type)
             raise Exception(f"Rebooting system due to {self.consecutive_sensor_errors} sensor failures")
 
+    def _flush_offline_buffer(self) -> bool:
+        """Send buffered readings to the API batch endpoint. Returns True if successful or buffer was empty."""
+        buffered = self.offline_buffer.get_buffered_readings()
+        if not buffered:
+            return True
+
+        print(f"Flushing {len(buffered)} buffered reading(s) to API")
+        readings = [
+            {**entry['payload'], 'taken_at': entry['taken_at']}
+            for entry in buffered
+        ]
+
+        try:
+            response = make_api_request('sensors/batch-readings', json={'readings': readings})
+            if response.status_code == 201:
+                print(f"Successfully sent {len(readings)} buffered reading(s)")
+                self.offline_buffer.clear_buffer()
+                return True
+            else:
+                print(f"Failed to flush buffer: {response.status_code} - {response.text}")
+                return False
+        except Exception:
+            print(f"Exception flushing buffer: {traceback.format_exc()}")
+            return False
+
     def run(self):
         """Main monitoring loop with resilient error handling"""
         print("Starting temperature monitoring")
+
+        # Flush any readings buffered during a previous offline period
+        self._flush_offline_buffer()
 
         recovery_attempted = False
         api_failure_count = 0
@@ -176,18 +206,23 @@ class TemperatureMonitor:
                     self.network_failure_count = 0
                     self.reboot_count = 0
                     reset_network_status()
+                    # Flush readings buffered during the offline period
+                    self._flush_offline_buffer()
 
                 recovery_attempted = False
 
+                taken_at = None
+                payload = None
                 try:
                     self.obtain_api_token()
 
                     temperature = self.read_temperature()
 
+                    taken_at = datetime.utcnow().isoformat() + 'Z'
                     payload = {
                         "degrees_c": temperature,
                         "cpu_degrees_c": CPUTemperature().temperature,
-                        "taken_at": datetime.utcnow().isoformat() + 'Z',
+                        "taken_at": taken_at,
                         'battery_level': self.pisugar.get_battery_level(),
                         'battery_amps': self.pisugar.get_current(),
                         'battery_volts': self.pisugar.get_voltage(),
@@ -229,6 +264,15 @@ class TemperatureMonitor:
                     # Only change LED state after persistent API failures
                     if api_failure_count >= 3:
                         self.led_control.set_state("error")
+
+                    # Buffer the reading only when connectivity is failing (not auth/config errors)
+                    if payload is not None and taken_at is not None and not test_internet_connectivity():
+                        try:
+                            self.offline_buffer.prune_to_limit()
+                            self.offline_buffer.add_reading(payload, taken_at)
+                            print(f"Reading buffered offline (buffer size: {self.offline_buffer.count()})")
+                        except Exception:
+                            print(f"Failed to buffer reading: {traceback.format_exc()}")
 
                 if len(self.consecutive_errors) > 0:
                     self.report_consecutive_errors()

--- a/tests/test_offline_buffer.py
+++ b/tests/test_offline_buffer.py
@@ -1,0 +1,139 @@
+"""Unit tests for offline_buffer.py"""
+import json
+import os
+import sys
+import tempfile
+import pytest
+
+# Add raspberry_pi to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'raspberry_pi'))
+
+from offline_buffer import OfflineBuffer
+
+
+@pytest.fixture
+def buffer(tmp_path):
+    """Provide a fresh OfflineBuffer backed by a temp directory."""
+    db_path = str(tmp_path / 'test_buffer.db')
+    return OfflineBuffer(db_path=db_path)
+
+
+SAMPLE_PAYLOAD = {
+    'degrees_c': -80.2,
+    'cpu_degrees_c': 45.0,
+    'battery_level': 95.0,
+}
+SAMPLE_TIMESTAMP = '2026-03-04T10:00:00Z'
+
+
+class TestAddReading:
+    def test_add_single_reading(self, buffer):
+        buffer.add_reading(SAMPLE_PAYLOAD, SAMPLE_TIMESTAMP)
+        assert buffer.count() == 1
+
+    def test_add_multiple_readings(self, buffer):
+        for i in range(5):
+            buffer.add_reading({'degrees_c': float(i)}, f'2026-03-04T10:0{i}:00Z')
+        assert buffer.count() == 5
+
+    def test_payload_is_persisted(self, buffer):
+        buffer.add_reading(SAMPLE_PAYLOAD, SAMPLE_TIMESTAMP)
+        readings = buffer.get_buffered_readings()
+        assert readings[0]['payload'] == SAMPLE_PAYLOAD
+
+    def test_timestamp_is_persisted(self, buffer):
+        buffer.add_reading(SAMPLE_PAYLOAD, SAMPLE_TIMESTAMP)
+        readings = buffer.get_buffered_readings()
+        assert readings[0]['taken_at'] == SAMPLE_TIMESTAMP
+
+
+class TestGetBufferedReadings:
+    def test_empty_buffer_returns_empty_list(self, buffer):
+        assert buffer.get_buffered_readings() == []
+
+    def test_returns_readings_in_fifo_order(self, buffer):
+        timestamps = [
+            '2026-03-04T10:00:00Z',
+            '2026-03-04T10:01:00Z',
+            '2026-03-04T10:02:00Z',
+        ]
+        for ts in timestamps:
+            buffer.add_reading({'degrees_c': -80.0}, ts)
+
+        readings = buffer.get_buffered_readings()
+        assert [r['taken_at'] for r in readings] == timestamps
+
+    def test_returns_id_field(self, buffer):
+        buffer.add_reading(SAMPLE_PAYLOAD, SAMPLE_TIMESTAMP)
+        readings = buffer.get_buffered_readings()
+        assert 'id' in readings[0]
+        assert readings[0]['id'] > 0
+
+
+class TestClearBuffer:
+    def test_clear_empties_buffer(self, buffer):
+        buffer.add_reading(SAMPLE_PAYLOAD, SAMPLE_TIMESTAMP)
+        buffer.clear_buffer()
+        assert buffer.count() == 0
+
+    def test_clear_on_empty_buffer_is_safe(self, buffer):
+        buffer.clear_buffer()  # Should not raise
+        assert buffer.count() == 0
+
+    def test_clear_removes_all_readings(self, buffer):
+        for i in range(10):
+            buffer.add_reading({'degrees_c': float(i)}, f'2026-03-04T10:{i:02d}:00Z')
+        buffer.clear_buffer()
+        assert buffer.count() == 0
+
+
+class TestPruneToLimit:
+    def test_prune_removes_oldest_when_over_limit(self, buffer):
+        timestamps = [f'2026-03-04T{h:02d}:00:00Z' for h in range(10)]
+        for ts in timestamps:
+            buffer.add_reading({'degrees_c': -80.0}, ts)
+
+        buffer.prune_to_limit(limit=5)
+        assert buffer.count() == 5
+
+    def test_prune_keeps_newest_readings(self, buffer):
+        timestamps = [f'2026-03-04T{h:02d}:00:00Z' for h in range(10)]
+        for ts in timestamps:
+            buffer.add_reading({'degrees_c': -80.0}, ts)
+
+        buffer.prune_to_limit(limit=5)
+        remaining = buffer.get_buffered_readings()
+        # Should have kept the 5 most recent (hours 5–9)
+        kept_timestamps = [r['taken_at'] for r in remaining]
+        assert kept_timestamps == timestamps[5:]
+
+    def test_prune_does_nothing_when_under_limit(self, buffer):
+        for i in range(3):
+            buffer.add_reading({'degrees_c': float(i)}, f'2026-03-04T10:0{i}:00Z')
+        buffer.prune_to_limit(limit=10)
+        assert buffer.count() == 3
+
+    def test_prune_default_limit_is_1440(self, buffer):
+        # Add exactly 1440 readings — should not prune any
+        for i in range(1440):
+            buffer.add_reading({'degrees_c': -80.0}, f'2026-03-04T00:{i // 60:02d}:{i % 60:02d}Z')
+        buffer.prune_to_limit()
+        assert buffer.count() == 1440
+
+    def test_prune_1441_drops_one(self, buffer):
+        for i in range(1441):
+            buffer.add_reading({'degrees_c': -80.0}, f'2026-03-04T00:{i // 60:02d}:{i % 60:02d}Z')
+        buffer.prune_to_limit()
+        assert buffer.count() == 1440
+
+
+class TestPersistence:
+    def test_readings_survive_across_instances(self, tmp_path):
+        db_path = str(tmp_path / 'persist_test.db')
+        buf1 = OfflineBuffer(db_path=db_path)
+        buf1.add_reading(SAMPLE_PAYLOAD, SAMPLE_TIMESTAMP)
+
+        buf2 = OfflineBuffer(db_path=db_path)
+        readings = buf2.get_buffered_readings()
+        assert len(readings) == 1
+        assert readings[0]['payload'] == SAMPLE_PAYLOAD

--- a/tests/test_temperature_monitor.py
+++ b/tests/test_temperature_monitor.py
@@ -85,6 +85,14 @@ def mock_dependencies():
     sys.modules['restarts'] = mock_restarts
     mocks['restarts'] = mock_restarts
 
+    # Mock offline_buffer so TemperatureMonitor doesn't try to create /home/pi
+    mock_offline_buffer_inst = MagicMock()
+    mock_offline_buffer_cls = MagicMock(return_value=mock_offline_buffer_inst)
+    offline_buffer_mod = MagicMock()
+    offline_buffer_mod.OfflineBuffer = mock_offline_buffer_cls
+    sys.modules['offline_buffer'] = offline_buffer_mod
+    mocks['offline_buffer'] = mock_offline_buffer_inst
+
     # Mock RPi.GPIO
     sys.modules['RPi'] = MagicMock()
     sys.modules['RPi.GPIO'] = MagicMock()
@@ -97,7 +105,8 @@ def mock_dependencies():
     # Cleanup
     for mod_name in ['temperature_monitor', 'config', 'api', 'led_control',
                      'freezerbot_setup', 'battery', 'network', 'device_info',
-                     'restarts', 'w1thermsensor', 'gpiozero', 'RPi', 'RPi.GPIO']:
+                     'restarts', 'w1thermsensor', 'gpiozero', 'RPi', 'RPi.GPIO',
+                     'offline_buffer']:
         sys.modules.pop(mod_name, None)
 
 


### PR DESCRIPTION
## What

When the Freezerbot API is unreachable due to a connectivity failure, temperature readings are now stored locally in a SQLite buffer and sent as a batch once connectivity is restored.

## Changes

### `raspberry_pi/offline_buffer.py` (new)
- `OfflineBuffer` class backed by SQLite at `/home/pi/.config/freezerbot/readings_buffer.db`
- `add_reading(payload, timestamp)` — stores reading with original timestamp
- `get_buffered_readings()` — returns all buffered readings in FIFO order
- `clear_buffer()` — deletes all readings after successful batch send
- `prune_to_limit(limit=1440)` — drops oldest readings to cap at 24h (1 reading/min)

### `raspberry_pi/temperature_monitor.py`
- Flushes buffer on startup (in case readings were captured during a prior offline period)
- Flushes buffer on connectivity restore before resuming normal operation
- Buffers current reading on API send failure **only** when connectivity test fails — auth errors (4xx) and config issues are intentionally excluded
- Sends buffered readings to `POST /api/sensors/batch-readings`

### `tests/test_offline_buffer.py` (new)
- 16 unit tests covering add, retrieve, clear, prune, and cross-instance persistence

## Testing

```
python3 -m pytest tests/test_offline_buffer.py -v
# 16 passed
```

## Related

Companion PR in freezerbot-api adds the `POST /api/sensors/batch-readings` endpoint.