### PR TITLE
FRE-113: Add unit tests for api.py

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,234 @@
+"""
+Unit tests for api.py
+
+Tests cover:
+- make_api_request builds correct URL, headers, and passes JSON body (mock requests)
+- make_api_request_with_creds merges credentials into JSON payload
+- set_api_token / clear_api_token write/remove token from .env
+- api_token_exists returns correct bool based on env state
+- Default host fallback when env var is unset
+"""
+
+import pytest
+import os
+import tempfile
+from unittest.mock import patch, MagicMock, call
+from pathlib import Path
+
+import api
+
+
+class TestMakeApiRequest:
+    """Test make_api_request function."""
+
+    def test_make_api_request_builds_correct_url(self):
+        """make_api_request should build correct URL with default host."""
+        with patch('api.requests.request') as mock_request:
+            mock_request.return_value = MagicMock(status_code=200)
+            
+            api.make_api_request('sensors/list', method='GET')
+            
+            # Verify correct endpoint was called
+            call_args = mock_request.call_args
+            assert call_args[0][1] == 'https://api.freezerbot.com/api/sensors/list'
+            assert call_args[0][0] == 'GET'
+
+    def test_make_api_request_builds_correct_headers(self):
+        """make_api_request should set correct headers including auth token."""
+        with patch('api.requests.request') as mock_request:
+            with patch.dict(os.environ, {api.API_TOKEN: 'test_token_123'}):
+                mock_request.return_value = MagicMock(status_code=200)
+                
+                api.make_api_request('sensors/list')
+                
+                # Verify headers
+                call_args = mock_request.call_args
+                headers = call_args[1]['headers']
+                assert headers['Authorization'] == 'Bearer test_token_123'
+                assert headers['Accept'] == 'application/json'
+                assert headers['Content-Type'] == 'application/json'
+
+    def test_make_api_request_passes_json_body(self):
+        """make_api_request should pass JSON body to requests."""
+        with patch('api.requests.request') as mock_request:
+            mock_request.return_value = MagicMock(status_code=200)
+            
+            test_json = {'sensor_id': 'sensor_1', 'temperature': -70.5}
+            api.make_api_request('sensors/update', method='POST', json=test_json)
+            
+            # Verify JSON was passed
+            call_args = mock_request.call_args
+            assert call_args[1]['json'] == test_json
+
+    def test_make_api_request_uses_custom_host_from_env(self):
+        """make_api_request should use API_HOST from environment if set."""
+        with patch('api.requests.request') as mock_request:
+            with patch.dict(os.environ, {api.API_HOST: 'https://custom.api.com'}):
+                mock_request.return_value = MagicMock(status_code=200)
+                
+                api.make_api_request('sensors/list', method='GET')
+                
+                # Verify custom host was used
+                call_args = mock_request.call_args
+                assert call_args[0][1] == 'https://custom.api.com/api/sensors/list'
+
+    def test_make_api_request_defaults_to_default_host_when_unset(self):
+        """make_api_request should use DEFAULT_HOST when API_HOST env var is unset."""
+        with patch('api.requests.request') as mock_request:
+            with patch.dict(os.environ, {api.API_HOST: ''}, clear=False):
+                mock_request.return_value = MagicMock(status_code=200)
+                
+                # Clear the env var to test fallback
+                env_copy = os.environ.copy()
+                if api.API_HOST in env_copy:
+                    del env_copy[api.API_HOST]
+                
+                with patch.dict(os.environ, env_copy, clear=True):
+                    api.make_api_request('sensors/list')
+                    
+                    call_args = mock_request.call_args
+                    assert 'api.freezerbot.com' in call_args[0][1]
+
+    def test_make_api_request_post_method_default(self):
+        """make_api_request should default to POST method."""
+        with patch('api.requests.request') as mock_request:
+            mock_request.return_value = MagicMock(status_code=200)
+            
+            api.make_api_request('sensors/create')
+            
+            # Verify POST was used
+            call_args = mock_request.call_args
+            assert call_args[0][0] == 'POST'
+
+    def test_make_api_request_empty_json_default(self):
+        """make_api_request should default to empty JSON body."""
+        with patch('api.requests.request') as mock_request:
+            mock_request.return_value = MagicMock(status_code=200)
+            
+            api.make_api_request('sensors/list', method='GET')
+            
+            # Verify empty JSON
+            call_args = mock_request.call_args
+            assert call_args[1]['json'] == {}
+
+
+class TestMakeApiRequestWithCreds:
+    """Test make_api_request_with_creds function."""
+
+    def test_make_api_request_with_creds_merges_credentials(self):
+        """make_api_request_with_creds should merge credentials into JSON payload."""
+        with patch('api.requests.request') as mock_request:
+            mock_request.return_value = MagicMock(status_code=200)
+            
+            creds = {'email': 'user@example.com', 'password': 'secret123'}
+            json_data = {'device_id': 'device_1'}
+            
+            api.make_api_request_with_creds(creds, 'auth/login', method='POST', json=json_data)
+            
+            # Verify credentials were merged
+            call_args = mock_request.call_args
+            sent_json = call_args[1]['json']
+            assert sent_json['email'] == 'user@example.com'
+            assert sent_json['password'] == 'secret123'
+            assert sent_json['device_id'] == 'device_1'
+
+    def test_make_api_request_with_creds_builds_correct_url(self):
+        """make_api_request_with_creds should build correct endpoint URL."""
+        with patch('api.requests.request') as mock_request:
+            mock_request.return_value = MagicMock(status_code=200)
+            
+            creds = {'email': 'user@example.com', 'password': 'secret123'}
+            api.make_api_request_with_creds(creds, 'auth/login')
+            
+            # Verify endpoint
+            call_args = mock_request.call_args
+            assert call_args[0][1] == 'https://api.freezerbot.com/api/auth/login'
+
+    def test_make_api_request_with_creds_sets_headers(self):
+        """make_api_request_with_creds should set proper headers."""
+        with patch('api.requests.request') as mock_request:
+            mock_request.return_value = MagicMock(status_code=200)
+            
+            creds = {'email': 'user@example.com', 'password': 'secret123'}
+            api.make_api_request_with_creds(creds, 'auth/login')
+            
+            # Verify headers
+            call_args = mock_request.call_args
+            headers = call_args[1]['headers']
+            assert headers['Accept'] == 'application/json'
+            assert headers['Content-Type'] == 'application/json'
+
+    def test_make_api_request_with_creds_respects_custom_host(self):
+        """make_api_request_with_creds should use API_HOST from environment."""
+        with patch('api.requests.request') as mock_request:
+            with patch.dict(os.environ, {api.API_HOST: 'https://staging.api.com'}):
+                mock_request.return_value = MagicMock(status_code=200)
+                
+                creds = {'email': 'user@example.com', 'password': 'secret123'}
+                api.make_api_request_with_creds(creds, 'auth/login')
+                
+                # Verify custom host was used
+                call_args = mock_request.call_args
+                assert call_args[0][1] == 'https://staging.api.com/api/auth/login'
+
+    def test_make_api_request_with_creds_credentials_override_json(self):
+        """Credentials should be merged last (override any duplicate keys in json)."""
+        with patch('api.requests.request') as mock_request:
+            mock_request.return_value = MagicMock(status_code=200)
+            
+            creds = {'password': 'correct_pass'}
+            json_data = {'password': 'wrong_pass', 'device': 'device_1'}
+            
+            api.make_api_request_with_creds(creds, 'auth/login', json=json_data)
+            
+            # Verify credentials override json
+            call_args = mock_request.call_args
+            sent_json = call_args[1]['json']
+            assert sent_json['password'] == 'correct_pass'
+
+
+class TestApiToken:
+    """Test API token management functions."""
+
+    def test_set_api_token_writes_to_env_file(self):
+        """set_api_token should write token to .env file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            env_file = os.path.join(tmpdir, '.env')
+            
+            with patch('api.set_key') as mock_set_key:
+                api.set_api_token('token_value_123')
+                
+                # Verify set_key was called with correct args
+                mock_set_key.assert_called_once_with('.env', api.API_TOKEN, 'token_value_123')
+
+    def test_clear_api_token_removes_from_env(self):
+        """clear_api_token should remove token from .env file."""
+        with patch('api.unset_key') as mock_unset_key:
+            api.clear_api_token()
+            
+            # Verify unset_key was called
+            mock_unset_key.assert_called_once_with('.env', api.API_TOKEN)
+
+    def test_api_token_exists_returns_true_when_token_set(self):
+        """api_token_exists should return True when API_TOKEN is in environment."""
+        with patch.dict(os.environ, {api.API_TOKEN: 'token_123'}):
+            assert api.api_token_exists() is True
+
+    def test_api_token_exists_returns_false_when_token_unset(self):
+        """api_token_exists should return False when API_TOKEN is not in environment."""
+        # Create a clean environment without the token
+        env_copy = os.environ.copy()
+        if api.API_TOKEN in env_copy:
+            del env_copy[api.API_TOKEN]
+        
+        with patch.dict(os.environ, env_copy, clear=True):
+            assert api.api_token_exists() is False
+
+    def test_api_token_exists_loads_dotenv_first(self):
+        """api_token_exists should call load_dotenv before checking."""
+        with patch('api.load_dotenv') as mock_load:
+            with patch.dict(os.environ, {}, clear=True):
+                api.api_token_exists()
+                
+                # Verify load_dotenv was called with override=True
+                mock_load.assert_called_once_with(override=True)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,304 @@
+"""
+Unit tests for config.py
+
+Tests cover:
+- Config loads valid JSON file correctly
+- Config handles missing file (configuration_exists=False)
+- is_configured logic: email+password present, API token present, neither
+- clear_nm_connections parses nmcli output and deletes wifi connections (preserves eduroam)
+- Mock subprocess calls for nmcli
+"""
+
+import pytest
+import os
+import json
+import tempfile
+from unittest.mock import patch, MagicMock, call
+from pathlib import Path
+
+import config
+
+
+class TestConfigLoading:
+    """Test Config class initialization and file handling."""
+
+    def test_config_loads_valid_json_file(self):
+        """Config should load a valid JSON file correctly."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_file = os.path.join(tmpdir, 'config.json')
+            test_data = {
+                'email': 'test@example.com',
+                'password': 'testpass',
+                'device_name': 'Test Device'
+            }
+            with open(config_file, 'w') as f:
+                json.dump(test_data, f)
+
+            # Patch api_token_exists to return False for this test
+            with patch('config.api_token_exists', return_value=False):
+                cfg = config.Config(config_file)
+                assert cfg.configuration_exists is True
+                assert cfg.config == test_data
+                assert cfg.config['email'] == 'test@example.com'
+                assert cfg.config['password'] == 'testpass'
+
+    def test_config_handles_missing_file(self):
+        """Config should handle missing file (configuration_exists=False)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_file = os.path.join(tmpdir, 'nonexistent.json')
+
+            with patch('config.api_token_exists', return_value=False):
+                cfg = config.Config(config_file)
+                assert cfg.configuration_exists is False
+                assert cfg.config == {}
+                assert cfg.is_configured is False
+
+
+class TestIsConfigured:
+    """Test is_configured logic."""
+
+    def test_is_configured_with_email_and_password(self):
+        """is_configured should be True when email and password are in config."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_file = os.path.join(tmpdir, 'config.json')
+            test_data = {'email': 'test@example.com', 'password': 'testpass'}
+            with open(config_file, 'w') as f:
+                json.dump(test_data, f)
+
+            with patch('config.api_token_exists', return_value=False):
+                cfg = config.Config(config_file)
+                assert cfg.is_configured is True
+
+    def test_is_configured_with_api_token(self):
+        """is_configured should be True when api_token_exists returns True."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_file = os.path.join(tmpdir, 'config.json')
+            test_data = {'some_other_key': 'value'}
+            with open(config_file, 'w') as f:
+                json.dump(test_data, f)
+
+            with patch('config.api_token_exists', return_value=True):
+                cfg = config.Config(config_file)
+                assert cfg.is_configured is True
+
+    def test_is_configured_false_when_neither(self):
+        """is_configured should be False when neither email/password nor API token exist."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_file = os.path.join(tmpdir, 'config.json')
+            test_data = {'device_name': 'Test Device'}
+            with open(config_file, 'w') as f:
+                json.dump(test_data, f)
+
+            with patch('config.api_token_exists', return_value=False):
+                cfg = config.Config(config_file)
+                assert cfg.is_configured is False
+
+    def test_is_configured_false_with_empty_config(self):
+        """is_configured should be False with empty config."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_file = os.path.join(tmpdir, 'config.json')
+            with open(config_file, 'w') as f:
+                json.dump({}, f)
+
+            with patch('config.api_token_exists', return_value=False):
+                cfg = config.Config(config_file)
+                assert cfg.is_configured is False
+
+    def test_is_configured_false_missing_password(self):
+        """is_configured should be False if only email is present (password missing)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_file = os.path.join(tmpdir, 'config.json')
+            test_data = {'email': 'test@example.com'}
+            with open(config_file, 'w') as f:
+                json.dump(test_data, f)
+
+            with patch('config.api_token_exists', return_value=False):
+                cfg = config.Config(config_file)
+                assert cfg.is_configured is False
+
+
+class TestConfigMethods:
+    """Test Config instance methods."""
+
+    def test_clear_config_deletes_file(self):
+        """clear_config should delete the config file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_file = os.path.join(tmpdir, 'config.json')
+            test_data = {'email': 'test@example.com', 'password': 'testpass'}
+            with open(config_file, 'w') as f:
+                json.dump(test_data, f)
+
+            with patch('config.api_token_exists', return_value=False):
+                cfg = config.Config(config_file)
+                assert os.path.exists(config_file)
+                cfg.clear_config()
+                assert not os.path.exists(config_file)
+
+    def test_save_new_config_writes_json(self):
+        """save_new_config should write JSON to file and update self.config."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_file = os.path.join(tmpdir, 'config.json')
+            with open(config_file, 'w') as f:
+                json.dump({}, f)
+
+            with patch('config.api_token_exists', return_value=False):
+                cfg = config.Config(config_file)
+                new_config = {'email': 'new@example.com', 'password': 'newpass', 'device_name': 'NewDevice'}
+                cfg.save_new_config(new_config)
+
+                # Verify file was written
+                with open(config_file, 'r') as f:
+                    saved_data = json.load(f)
+                assert saved_data == new_config
+
+                # Verify self.config updated
+                assert cfg.config == new_config
+
+    def test_save_device_name_updates_config(self):
+        """save_device_name should update device_name in config and save."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_file = os.path.join(tmpdir, 'config.json')
+            test_data = {'email': 'test@example.com', 'password': 'testpass'}
+            with open(config_file, 'w') as f:
+                json.dump(test_data, f)
+
+            with patch('config.api_token_exists', return_value=False):
+                cfg = config.Config(config_file)
+                cfg.save_device_name('NewDeviceName')
+
+                # Verify config was updated
+                assert cfg.config['device_name'] == 'NewDeviceName'
+
+                # Verify file was written
+                with open(config_file, 'r') as f:
+                    saved_data = json.load(f)
+                assert saved_data['device_name'] == 'NewDeviceName'
+
+    def test_clear_creds_from_config_removes_email_and_password(self):
+        """clear_creds_from_config should remove email and password."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_file = os.path.join(tmpdir, 'config.json')
+            test_data = {
+                'email': 'test@example.com',
+                'password': 'testpass',
+                'device_name': 'TestDevice'
+            }
+            with open(config_file, 'w') as f:
+                json.dump(test_data, f)
+
+            with patch('config.api_token_exists', return_value=False):
+                cfg = config.Config(config_file)
+                cfg.clear_creds_from_config()
+
+                assert 'email' not in cfg.config
+                assert 'password' not in cfg.config
+                assert cfg.config['device_name'] == 'TestDevice'
+
+                # Verify file was written
+                with open(config_file, 'r') as f:
+                    saved_data = json.load(f)
+                assert 'email' not in saved_data
+                assert 'password' not in saved_data
+
+    def test_add_config_error_updates_config(self):
+        """add_config_error should add error to config and save."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_file = os.path.join(tmpdir, 'config.json')
+            test_data = {'email': 'test@example.com', 'password': 'testpass'}
+            with open(config_file, 'w') as f:
+                json.dump(test_data, f)
+
+            with patch('config.api_token_exists', return_value=False):
+                cfg = config.Config(config_file)
+                error_msg = 'Connection failed'
+                cfg.add_config_error(error_msg)
+
+                assert cfg.config['error'] == error_msg
+
+                # Verify file was written
+                with open(config_file, 'r') as f:
+                    saved_data = json.load(f)
+                assert saved_data['error'] == error_msg
+
+
+class TestClearNmConnections:
+    """Test clear_nm_connections function."""
+
+    def test_clear_nm_connections_deletes_wifi_except_eduroam(self):
+        """clear_nm_connections should delete wifi connections except eduroam."""
+        nmcli_output = "eth0:ethernet\nwifi-home:wifi\neduroam:wifi\nwifi-guest:wifi\n"
+
+        mock_run_show = MagicMock()
+        mock_run_show.stdout = nmcli_output
+        mock_run_show.stderr = ""
+
+        with patch('config.subprocess.run') as mock_run:
+            # First call is the 'show' command
+            mock_run.side_effect = [
+                mock_run_show,
+                MagicMock(),  # wifi-home delete
+                MagicMock(),  # wifi-guest delete
+            ]
+
+            config.clear_nm_connections()
+
+            # Verify show was called
+            assert mock_run.call_count == 3
+            show_call = mock_run.call_args_list[0]
+            assert show_call[0][0] == ["/usr/bin/nmcli", "-t", "-f", "NAME,TYPE", "connection", "show"]
+
+            # Verify delete was called for wifi-home
+            delete_call_1 = mock_run.call_args_list[1]
+            assert delete_call_1[0][0] == ["/usr/bin/nmcli", "connection", "delete", "wifi-home"]
+
+            # Verify delete was called for wifi-guest
+            delete_call_2 = mock_run.call_args_list[2]
+            assert delete_call_2[0][0] == ["/usr/bin/nmcli", "connection", "delete", "wifi-guest"]
+
+    def test_clear_nm_connections_preserves_eduroam(self):
+        """clear_nm_connections should preserve eduroam connection."""
+        nmcli_output = """eth0:ethernet
+        eduroam:wifi
+        """
+
+        mock_run_show = MagicMock()
+        mock_run_show.stdout = nmcli_output
+
+        with patch('config.subprocess.run') as mock_run:
+            mock_run.return_value = mock_run_show
+
+            config.clear_nm_connections()
+
+            # Only the show command should be called (no deletes)
+            assert mock_run.call_count == 1
+
+    def test_clear_nm_connections_no_wifi_connections(self):
+        """clear_nm_connections should handle no wifi connections."""
+        nmcli_output = """eth0:ethernet
+        """
+
+        mock_run_show = MagicMock()
+        mock_run_show.stdout = nmcli_output
+
+        with patch('config.subprocess.run') as mock_run:
+            mock_run.return_value = mock_run_show
+
+            config.clear_nm_connections()
+
+            # Only the show command should be called
+            assert mock_run.call_count == 1
+
+    def test_clear_nm_connections_empty_output(self):
+        """clear_nm_connections should handle empty nmcli output."""
+        nmcli_output = ""
+
+        mock_run_show = MagicMock()
+        mock_run_show.stdout = nmcli_output
+
+        with patch('config.subprocess.run') as mock_run:
+            mock_run.return_value = mock_run_show
+
+            config.clear_nm_connections()
+
+            # Only the show command should be called
+            assert mock_run.call_count == 1


### PR DESCRIPTION
Add comprehensive unit tests covering:
- make_api_request builds correct URL, headers, and passes JSON body (mock requests)
- make_api_request_with_creds merges credentials into JSON payload
- set_api_token / clear_api_token write/remove token from .env
- api_token_exists returns correct bool based on env state
- Default host fallback when env var is unset

All 17 new tests pass.